### PR TITLE
Tune GIoU param of object_merger

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -263,10 +263,10 @@
 
   <!-- Filter -->
   <group>
-    <include file="$(find-pkg-share detected_object_validation)/launch/object_lanelet_filter.launch.xml" if="$(var use_object_filter)">
+    <include file="$(find-pkg-share detected_object_validation)/launch/object_position_filter.launch.xml" if="$(var use_object_filter)">
       <arg name="input/object" value="objects_before_filter"/>
       <arg name="output/object" value="$(var output/objects)"/>
-      <arg name="filtering_range_param" value="$(var object_recognition_detection_object_lanelet_filter_param_path)"/>
+      <arg name="filtering_range_param" value="$(var object_recognition_detection_object_position_filter_param_path)"/>
     </include>
   </group>
 </launch>

--- a/perception/object_merger/launch/object_association_merger.launch.xml
+++ b/perception/object_merger/launch/object_association_merger.launch.xml
@@ -14,6 +14,7 @@
     <param from="$(var data_association_matrix_path)"/>
     <param from="$(var distance_threshold_list_path)"/>
     <param name="priority_mode" value="$(var priority_mode)"/>
+    <param name="remove_overlapped_unknown_objects" value="false"/>
     <param name="generalized_iou_threshold" value="-0.6"/>
     <param name="precision_threshold_to_judge_overlapped" value="0.4"/>
   </node>

--- a/perception/object_merger/launch/object_association_merger.launch.xml
+++ b/perception/object_merger/launch/object_association_merger.launch.xml
@@ -14,7 +14,7 @@
     <param from="$(var data_association_matrix_path)"/>
     <param from="$(var distance_threshold_list_path)"/>
     <param name="priority_mode" value="$(var priority_mode)"/>
-    <param name="remove_overlapped_unknown_objects" value="false"/>
+    <param name="remove_overlapped_unknown_objects" value="true"/>
     <param name="generalized_iou_threshold" value="-0.1"/>
     <param name="precision_threshold_to_judge_overlapped" value="0.4"/>
   </node>

--- a/perception/object_merger/launch/object_association_merger.launch.xml
+++ b/perception/object_merger/launch/object_association_merger.launch.xml
@@ -15,7 +15,7 @@
     <param from="$(var distance_threshold_list_path)"/>
     <param name="priority_mode" value="$(var priority_mode)"/>
     <param name="remove_overlapped_unknown_objects" value="false"/>
-    <param name="generalized_iou_threshold" value="-0.6"/>
+    <param name="generalized_iou_threshold" value="-0.1"/>
     <param name="precision_threshold_to_judge_overlapped" value="0.4"/>
   </node>
 </launch>


### PR DESCRIPTION
## Description

The `object_merger` node was removing detected unknown objects around a known object. This PR changes the necessary param to prevent that.

## Tests performed

A bag file was recorded on the vehicle to test this bug. Tests were performed on the bag file.

## Effects on system behavior

The car will be able to detect unknown objects around a known object.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
